### PR TITLE
Avoid PHP Runtime Deprecation Notice

### DIFF
--- a/Classes/Service/IrreService.php
+++ b/Classes/Service/IrreService.php
@@ -77,7 +77,7 @@ class IrreService {
                 $elementRows = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
                     'uid',
                     'tt_content',
-                    'foreign_uid = ' . $data['uid'] . (TYPO3_MODE == 'BE' ? \TYPO3\CMS\Backend\Utility\BackendUtility::BEenableFields($tableName) : $contentObj->enableFields('tt_content')) . 'AND parent_table = "' . $parentTable . '"',
+                    'foreign_uid = ' . $data['uid'] . (TYPO3_MODE == 'BE' ? \TYPO3\CMS\Backend\Utility\BackendUtility::BEenableFields('tt_content') : $contentObj->enableFields('tt_content')) . 'AND parent_table = "' . $parentTable . '"',
                     '',
                     'sorting'
                 );

--- a/Classes/Service/IrreService.php
+++ b/Classes/Service/IrreService.php
@@ -41,7 +41,7 @@ class IrreService {
 	 * @param string $tableName
 	 * @return array
 	 */
-	public function getRelations($contentObj, $tableName){
+    static public function getRelations($contentObj, $tableName){
 		$result = array();
 		if($contentObj->data[$tableName] > 0){
 
@@ -69,7 +69,7 @@ class IrreService {
      * @param string $parentTable
      * @return array
      */
-    public function getContentElements($contentObj, $data, $parentTable) {
+    static public function getContentElements($contentObj, $data, $parentTable) {
 
         if(is_array($data)) {
 


### PR DESCRIPTION
Refactoring of IrreService.php to avoid PHP Runtime Deprecation Notice and replaced unused variable
