### PR TITLE
[BUGFIX] Fixes url service in backend

### DIFF
--- a/Classes/Service/Url.php
+++ b/Classes/Service/Url.php
@@ -88,6 +88,11 @@ class Url {
 			$GLOBALS['TSFE'] = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\Controller\\TypoScriptFrontendController',  $GLOBALS['TYPO3_CONF_VARS'], $id, $typeNum);
 			$GLOBALS['TSFE']->connectToDB();
 			$GLOBALS['TSFE']->initFEuser();
+
+            if (TYPO3_MODE === 'BE') {
+                $GLOBALS['TSFE']->initializeBackendUser();
+            }
+
 			$GLOBALS['TSFE']->determineId();
 			$GLOBALS['TSFE']->initTemplate();
 			$GLOBALS['TSFE']->getConfigArray();


### PR DESCRIPTION
When initializing the TSFE in the backend for using the link builder
there was a problem with hidden pages. The TSFE could not initialize
without a backend user.

This commit adds a backend user initialization when used in the backend
context.
