### PR TITLE
[BUGFIX] adds colPos to showitems of all registered content elements

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -119,7 +119,7 @@ if (count($providers) > 0) {
 
                     //Add tab extends and if the palette "dwcAdditionalFields" exists add the fields of it
                     $TCA['tt_content']['types'][lcfirst($key)]['showitem'] .= ',
-                        --div--;LLL:EXT:cms/locallang_tca.xml:pages.tabs.extended,
+                        --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xml:pages.tabs.extended,
                         --palette--;LLL:EXT:' . $_EXTKEY .
                         '/Resources/Private/Language/locallang_db.xlf:palettes.dwcAdditionalFields;dwcAdditionalFields';
 
@@ -129,6 +129,9 @@ if (count($providers) > 0) {
                         $TCA['tt_content']['types'][lcfirst($key)]['showitem'] .=
                             ',tx_gridelements_container,tx_gridelements_columns';
                     }
+                    
+                    $TCA['tt_content']['types'][lcfirst($key)]['showitem'] .=
+                        ',colPos';
 
                     //Set rendering typoScript
                     $typoScript .= "\n


### PR DESCRIPTION
In a blank project for 7.6 there is no colPos definition for the custom contentelements created in dw_content_elements_source, therefore we have to add it permanently.
This should be done in dw_content_elements, because it affects all custom content elements, otherwise we have to add it in the content element typoscript configuration.
If we don't have colPos defined, we are not able to create new custom content elements in an other column than 0.
Furthermore, i updated the label for the extended tab, because LLL:EXT:cms/locallang_tca.xml:pages.tabs.extended is not present in 7.6 (beware: this change is not backwards compatible).